### PR TITLE
mention job name limit in example config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ defaults:
       value: '/mnt/user/appdata'
 
 jobs:
+  # job names are limited to 255 characters
   - name: Cleanup
     # override the default cron
     cron: '0 5 * * 0'


### PR DESCRIPTION
As mentioned in issue #12, submitting a pull request to update the example config file with the job name character limit, although now that the limit is 255 it seems much less necessary, but I'll leave the decision up to you.

Thanks for the quick fix!