### PR TITLE
Fix kopia installation

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM golang:1.25
+        FROM golang:1.25.2
         RUN wget -qO- https://deb.nodesource.com/setup_22.x -O setup.sh
         RUN bash setup.sh
 

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,16 +1,26 @@
-ARG V_GOLANG=1.25
+ARG V_GOLANG=1.25.2
 ARG V_DEBIAN=bookworm
-FROM golang:${V_GOLANG}-${V_DEBIAN} AS final
+FROM debian:${V_DEBIAN}-slim AS final
 
+# Keep this block the same as in the gorelease Dockerfile
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl wget ca-certificates tzdata unzip \
-    python3 python3-pip python3-venv pipx \
+    curl wget tar ca-certificates tzdata unzip dumb-init \
+    python3 python3-pip python3-venv pipx gnupg \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Add pipx binary location to PATH
-ENV PATH="/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:${PATH}"
 
-# air
+# Install go
+ARG V_GOLANG
+ARG TARGETARCH
+ENV GO_VERSION=$V_GOLANG
+RUN curl -fsSLo /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+    && tar -C /usr/local -xzf /tmp/go.tgz \
+    && rm /tmp/go.tgz
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
+
+# Install air
 RUN go install github.com/air-verse/air@latest
 
 WORKDIR /app

--- a/docker/goreleaser.dockerfile
+++ b/docker/goreleaser.dockerfile
@@ -20,13 +20,14 @@ RUN yarn build
 
 FROM debian:${V_DEBIAN}-slim AS final
 
+# Keep this block the same as in the dev Dockerfile
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl wget ca-certificates tzdata unzip dumb-init \
+    curl wget tar ca-certificates tzdata unzip dumb-init \
     python3 python3-pip python3-venv pipx gnupg \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Add pipx binary location to PATH
-ENV PATH="/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:${PATH}"
 
 WORKDIR /app
 


### PR DESCRIPTION
- This kopia installation is failing on version `v0.8.0`
```bash
veerendra@helium:/opt/docker/compose/gocron$ docker logs gocron
time=2025-10-10T21:44:35.102+02:00 level=INFO msg="Installing software" name=kopia
time=2025-10-10T21:44:35.534+02:00 level=ERROR msg=Failed err="exit status 127 - sh: 1: gpg: not found\n"
time=2025-10-10T21:44:35.534+02:00 level=INFO msg="Installing software" name=docker
time=2025-10-10T21:44:46.430+02:00 level=INFO msg=Done
time=2025-10-10T21:44:46.764+02:00 level=INFO msg="Starting server" url=http://0.0.0.0:8156
```
My config looks like below
```yaml
      log_level: 'info'
      delete_runs_after_days: 7
      software:
        - name: 'kopia'
        - name: 'docker'
...
```
- As in my previous PR https://github.com/flohoss/gocron/pull/35, added kopia installation, I only tested locally with dev docker compose (i.e. `docker/dev.dockerfile`) which the base image `golang:1.25-bookworm` has `gpg` package already installed, but in release docker file `docker/goreleaser.dockerfile`, the base image is `debian:bookworm-slim`, doesn't have debian:bookworm-slim.
- In this PR, `gnupg` package is added in release dockerfile

Testing

```bash
# As release docker file has base image "debian:bookworm-slim",
# run that image locally
docker run -it --rm debian:bookworm-slim

# gpg is unavailable
root@579353ae8b50:/# gpg
bash: gpg: command not found

# install
root@579353ae8b50:/# apt-get update && apt-get install gnupg -y

root@579353ae8b50:/# gpg
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
gpg: Go ahead and type your message ...
^C
gpg: signal Interrupt caught ... exiting

```
